### PR TITLE
Newer (simpler) OSX Rolling Spider Demo

### DIFF
--- a/Contributions/OSX/RollingSpiderCruft/Makefile
+++ b/Contributions/OSX/RollingSpiderCruft/Makefile
@@ -1,6 +1,6 @@
 LIBAR=../../../../ARSDKBuildUtils/Targets/Unix/Install
 
-FRAMEWORKS=-framework Foundation -framework CoreBluetooth
+FRAMEWORKS=-framework Foundation -framework CoreBluetooth -framework CoreGraphics
 INCLUDES=-I$(LIBAR)/include
 LIBDIR=-L$(LIBAR)/lib
 LIBS=-lardiscovery -larnetworkal -larsal -larnetwork -larcommands

--- a/Contributions/OSX/RollingSpiderCruft/RSlib/DeviceController+libARCommands.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/DeviceController+libARCommands.m
@@ -495,13 +495,12 @@ static void common_camerasettingsstate_camerasettingschanged_callback(float fov,
     cmdError = ARCOMMANDS_Generator_GenerateCommonSettingsAllSettings(cmdbuf, sizeof(cmdbuf), &actualSize);
     if (cmdError == ARCOMMANDS_GENERATOR_OK)
     {
-        sentStatus = [self sendData:cmdbuf withSize:actualSize onBufferWithId:bufferId withSendPolicy:policy withCompletionBlock:completionBlock];
+      sentStatus = [self sendData:cmdbuf withSize:actualSize onBufferWithId:bufferId withSendPolicy:policy withCompletionBlock:completionBlock];
     }
     if (!sentStatus)
     {
         ARSAL_PRINT(ARSAL_PRINT_ERROR, DeviceController_TAG, "Failed to send AllSettings command.");
     }
-
     return sentStatus;
 }
 - (BOOL)DeviceController_SendSettingsReset:(int)bufferId withSendPolicy:(eARNETWORK_SEND_POLICY)policy withCompletionBlock:(DeviceControllerCompletionBlock)completionBlock

--- a/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController+libARCommands.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController+libARCommands.m
@@ -212,9 +212,18 @@ static void minidrone_floodcontrolstate_floodcontrolchanged_callback(uint16_t de
     [[NSNotificationCenter defaultCenter] postNotificationName:MiniDroneDeviceControllerFloodControlStateFloodControlChangedNotification object:self userInfo:dict];
 }
 
+void batteryStateChangedCallback (uint8_t percent, void *custom)
+{
+    // callback of changing of battery level
+    DeviceController *deviceController = (__bridge MiniDroneDeviceController*)custom;
+    
+    NSLog(@"batteryStateChangedCallback ... %d  ; %@", percent, deviceController);
+}
 
 - (void)registerMiniDroneARCommandsCallbacks
 {
+    // Battery state
+    ARCOMMANDS_Decoder_SetCommonCommonStateBatteryStateChangedCallback(batteryStateChangedCallback, (__bridge void *)self);
     // Command class PilotingState
     ARCOMMANDS_Decoder_SetMiniDronePilotingStateFlatTrimChangedCallback(minidrone_pilotingstate_flattrimchanged_callback, (__bridge void *)(self));
     ARCOMMANDS_Decoder_SetMiniDronePilotingStateFlyingStateChangedCallback(minidrone_pilotingstate_flyingstatechanged_callback, (__bridge void *)(self));
@@ -240,6 +249,8 @@ static void minidrone_floodcontrolstate_floodcontrolchanged_callback(uint16_t de
 
 - (void)unregisterMiniDroneARCommandsCallbacks
 {
+    // Battery state
+    ARCOMMANDS_Decoder_SetCommonCommonStateBatteryStateChangedCallback (NULL, NULL);
     // Command class PilotingState
     ARCOMMANDS_Decoder_SetMiniDronePilotingStateFlatTrimChangedCallback(NULL, NULL);
     ARCOMMANDS_Decoder_SetMiniDronePilotingStateFlyingStateChangedCallback(NULL, NULL);

--- a/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
@@ -225,29 +225,28 @@ typedef struct
     
     if (isRunning)
     {
-      //switch(currentState)
-      //{
-      //case DEVICE_CONTROLLER_STATE_STARTED:
-                // Make a copy of the drone state.
-                [_droneStateLock lock];
-                localState = _droneState;
-                [_droneStateLock unlock];
-                NSLog(@"====> %d, %d, %d, %d, %d, %f", (uint8_t)(localState.pilotingData.active ? 1 : 0),
-                 (int8_t)(localState.pilotingData.roll * 100.f),
-                 (int8_t)(localState.pilotingData.pitch * 100.f),
-                 (int8_t)(localState.pilotingData.yaw * 100.f),
-                 (int8_t)(localState.pilotingData.gaz * 100.f),
-                 localState.pilotingData.heading);
-                [self MiniDroneDeviceController_SendPilotingPCMD:[MiniDroneARNetworkConfig c2dNackId] withSendPolicy:ARNETWORK_SEND_POLICY_DROP withCompletionBlock:nil withFlag:(uint8_t)(localState.pilotingData.active ? 1 : 0) withRoll:(int8_t)(localState.pilotingData.roll * 100.f) withPitch:(int8_t)(localState.pilotingData.pitch * 100.f) withYaw:(int8_t)(localState.pilotingData.yaw * 100.f) withGaz:(int8_t)(localState.pilotingData.gaz * 100.f) withPsi:localState.pilotingData.heading];
-                //break;
+      switch(currentState) {
+        case DEVICE_CONTROLLER_STATE_STARTED:
+	  // Make a copy of the drone state.
+	  [_droneStateLock lock];
+	  localState = _droneState;
+	  [_droneStateLock unlock];
+	  NSLog(@"====> %d, %d, %d, %d, %d, %f", (uint8_t)(localState.pilotingData.active ? 1 : 0),
+		(int8_t)(localState.pilotingData.roll * 100.f),
+		(int8_t)(localState.pilotingData.pitch * 100.f),
+		(int8_t)(localState.pilotingData.yaw * 100.f),
+		(int8_t)(localState.pilotingData.gaz * 100.f),
+		localState.pilotingData.heading);
+	  [self MiniDroneDeviceController_SendPilotingPCMD:[MiniDroneARNetworkConfig c2dNackId] withSendPolicy:ARNETWORK_SEND_POLICY_DROP withCompletionBlock:nil withFlag:(uint8_t)(localState.pilotingData.active ? 1 : 0) withRoll:(int8_t)(localState.pilotingData.roll * 100.f) withPitch:(int8_t)(localState.pilotingData.pitch * 100.f) withYaw:(int8_t)(localState.pilotingData.yaw * 100.f) withGaz:(int8_t)(localState.pilotingData.gaz * 100.f) withPsi:localState.pilotingData.heading];
+	  break;
                 
-		//case DEVICE_CONTROLLER_STATE_STOPPING:
-		//case DEVICE_CONTROLLER_STATE_STARTING:
-		//case DEVICE_CONTROLLER_STATE_STOPPED:
-		//default:
-                // DO NOT SEND DATA
-                //break;
-		//}
+        case DEVICE_CONTROLLER_STATE_STOPPING:
+        case DEVICE_CONTROLLER_STATE_STARTING:
+        case DEVICE_CONTROLLER_STATE_STOPPED:
+        default:
+	  //DO NOT SEND DATA
+	  break;
+      }
     }
 }
 

--- a/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
@@ -102,47 +102,41 @@ typedef struct
     [_stateLock lock];
     if (_state == DEVICE_CONTROLLER_STATE_STOPPED)
     {
-        _state = DEVICE_CONTROLLER_STATE_STARTING;
-        _startCancelled = NO;
-        _initialSettingsReceived = NO;
-        _initialStatesReceived = NO;
-
-        /* Asynchronously start the base controller. */
-
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerWillStartNotification object:self];
-            BOOL failed = NO;
-            if ([self privateStart] == NO)
-            {
-                ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Failed to start the controller.");
-                failed = YES;
-            }
-            if (!failed && !_startCancelled)
-            {
-                /* Go to the STARTED state and notify. */
-                [_stateLock lock];
-                _state = DEVICE_CONTROLLER_STATE_STARTED;
-                [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidStartNotification object:self];
-                [_stateLock unlock];
-            }
-            else
-            {
-                /* We failed to start. Go to the STOPPING state and stop in the background. */
-                [_stateLock lock];
-                _state = DEVICE_CONTROLLER_STATE_STOPPING;
-                if (failed) {
-                    [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidFailNotification object:self];
-                } // No else: Do not send failure notification for a cancelled start.
-                [_stateLock unlock];
-                [self privateStop];
-                
-                /* Go to the STOPPED state and notify. */
-                [_stateLock lock];
-                _state = DEVICE_CONTROLLER_STATE_STOPPED;
-                [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidStopNotification object:self];
-                [_stateLock unlock];
-            }
-	  });
+      _state = DEVICE_CONTROLLER_STATE_STARTING;
+      _startCancelled = NO;
+      _initialSettingsReceived = NO;
+      _initialStatesReceived = NO;
+      
+      
+      [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerWillStartNotification object:self];
+      BOOL failed = NO;
+      if ([self privateStart] == NO)
+	{
+	  ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Failed to start the controller.");
+	  failed = YES;
+	}
+      if (!failed && !_startCancelled)
+	{
+	  [_stateLock lock];
+	  _state = DEVICE_CONTROLLER_STATE_STARTED;
+	  [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidStartNotification object:self];
+	  [_stateLock unlock];
+	}
+      else
+	{
+	  [_stateLock lock];
+	  _state = DEVICE_CONTROLLER_STATE_STOPPING;
+	  if (failed) {
+	    [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidFailNotification object:self];
+	  } // No else: Do not send failure notification for a cancelled start.
+	  [_stateLock unlock];
+	  [self privateStop];
+          
+	  [_stateLock lock];
+	  _state = DEVICE_CONTROLLER_STATE_STOPPED;
+	  [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerDidStopNotification object:self];
+	  [_stateLock unlock];
+	}
     }
     [_stateLock unlock];
 }
@@ -231,29 +225,29 @@ typedef struct
     
     if (isRunning)
     {
-        switch(currentState)
-        {
-            case DEVICE_CONTROLLER_STATE_STARTED:
+      //switch(currentState)
+      //{
+      //case DEVICE_CONTROLLER_STATE_STARTED:
                 // Make a copy of the drone state.
                 [_droneStateLock lock];
                 localState = _droneState;
                 [_droneStateLock unlock];
-                /*NSLog(@"====> %d, %d, %d, %d, %d, %f", (uint8_t)(localState.pilotingData.active ? 1 : 0),
+                NSLog(@"====> %d, %d, %d, %d, %d, %f", (uint8_t)(localState.pilotingData.active ? 1 : 0),
                  (int8_t)(localState.pilotingData.roll * 100.f),
                  (int8_t)(localState.pilotingData.pitch * 100.f),
                  (int8_t)(localState.pilotingData.yaw * 100.f),
                  (int8_t)(localState.pilotingData.gaz * 100.f),
-                 localState.pilotingData.heading);*/
+                 localState.pilotingData.heading);
                 [self MiniDroneDeviceController_SendPilotingPCMD:[MiniDroneARNetworkConfig c2dNackId] withSendPolicy:ARNETWORK_SEND_POLICY_DROP withCompletionBlock:nil withFlag:(uint8_t)(localState.pilotingData.active ? 1 : 0) withRoll:(int8_t)(localState.pilotingData.roll * 100.f) withPitch:(int8_t)(localState.pilotingData.pitch * 100.f) withYaw:(int8_t)(localState.pilotingData.yaw * 100.f) withGaz:(int8_t)(localState.pilotingData.gaz * 100.f) withPsi:localState.pilotingData.heading];
-                break;
+                //break;
                 
-            case DEVICE_CONTROLLER_STATE_STOPPING:
-            case DEVICE_CONTROLLER_STATE_STARTING:
-            case DEVICE_CONTROLLER_STATE_STOPPED:
-            default:
+		//case DEVICE_CONTROLLER_STATE_STOPPING:
+		//case DEVICE_CONTROLLER_STATE_STARTING:
+		//case DEVICE_CONTROLLER_STATE_STOPPED:
+		//default:
                 // DO NOT SEND DATA
-                break;
-        }
+                //break;
+		//}
     }
 }
 
@@ -477,16 +471,12 @@ typedef struct
             ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Failed to start the base controller.");
         }
     }
-    
     if (!failed && !_startCancelled)
     {
-        // Register ARCommands callbacks.
-      //[self registerMiniDroneARCommandsCallbacks];
-#ifdef ARCOMMANDS_HAS_DEBUG_COMMANDS
-      //[self registerMiniDroneDebugARCommandsCallbacks];
-#endif
+      // Register ARCommands callbacks.
+      [self registerMiniDroneARCommandsCallbacks];
     }
-    
+
     if (!failed && !_startCancelled && !self.fastReconnection)
     {
         NSDate *currentDate = [NSDate date];
@@ -503,56 +493,14 @@ typedef struct
         [self DeviceController_SendCommonCurrentTime:[MiniDroneARNetworkConfig c2dAckId] withSendPolicy:ARNETWORK_SEND_POLICY_RETRY withCompletionBlock:nil withTime:(char *)[[dateFormatter stringFromDate:currentDate] cStringUsingEncoding:NSUTF8StringEncoding]];
     }
 
-    if (!failed && !_startCancelled && !self.fastReconnection)
-    {
-        // Attempt to get initial settings
-        [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerNotificationAllSettingsDidStart object:self userInfo:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(stateAllSettingsChanged:) name:DeviceControllerSettingsStateAllSettingsChangedNotification object:nil];
-        [self DeviceController_SendSettingsAllSettings:[MiniDroneARNetworkConfig c2dAckId] withSendPolicy:ARNETWORK_SEND_POLICY_RETRY withCompletionBlock:nil];
-        [_initialSettingsReceivedCondition lock];
-        [_initialSettingsReceivedCondition wait];
-        if (!_initialSettingsReceived)
-        {
-            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Initial settings retrieval timed out.");
-            failed = YES;
-        }
-        [_initialSettingsReceivedCondition unlock];
-    }
-    
-    if (!failed && !_startCancelled)
-    {
-        // Attempt to get initial states
-        [[NSNotificationCenter defaultCenter] postNotificationName:DeviceControllerNotificationAllStatesDidStart object:self userInfo:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(stateAllStatesChanged:) name:DeviceControllerCommonStateAllStatesChangedNotification object:nil];
-        [self DeviceController_SendCommonAllStates:[MiniDroneARNetworkConfig c2dAckId] withSendPolicy:ARNETWORK_SEND_POLICY_RETRY withCompletionBlock:nil];
-        [_initialStatesReceivedCondition lock];
-        [_initialStatesReceivedCondition wait];
-        if (!_initialStatesReceived)
-        {
-            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Initial states retrieval timed out.");
-            failed = YES;
-        }
-        [_initialStatesReceivedCondition unlock];
-    }
-
-    if (!failed && !_startCancelled)
-    {
-        [self registerCurrentProduct];
-        //_photoRecordController = [[MiniDronePhotoRecordController alloc] init];
-        //_photoRecordController.deviceController = self;
-    }
-
     return (failed == NO);
 }
 
 - (void)privateStop
 {
   //_photoRecordController = nil;
-  //[self unregisterMiniDroneARCommandsCallbacks];
-#ifdef ARCOMMANDS_HAS_DEBUG_COMMANDS
-  //[self unregisterMiniDroneDebugARCommandsCallbacks];
-#endif
-    [self stopBaseController];
+  [self unregisterMiniDroneARCommandsCallbacks];
+  [self stopBaseController];
 }
 
 - (void)stateAllSettingsChanged:(NSNotification *)notification

--- a/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
+++ b/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
@@ -83,7 +83,7 @@ void discover_drone() {
   [MDDC userRequestSetAutoTakeOffMode:1];
   [NSThread sleepForTimeInterval:0.3];
 
-  float speed = 0.50;
+  float speed = 0.30;
   
   int commandFound = 0;
   while(1) {

--- a/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
+++ b/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
@@ -79,13 +79,16 @@ void discover_drone() {
   [MDDC userRequestedFlatTrim];
   [NSThread sleepForTimeInterval:0.3];
  
-  NSLog(@"Blink Blink");
-  [MDDC userRequestSetAutoTakeOffMode:1];
-  [NSThread sleepForTimeInterval:0.3];
+  //NSLog(@"Blink Blink");
+  //[MDDC userRequestSetAutoTakeOffMode:1];
+  //[NSThread sleepForTimeInterval:0.3];
 
-  float speed = 0.30;
+  float speed = 0.50;
+  int land = 0;
   
   int commandFound = 0;
+
+  NSLog(@"Rolling Spider ready for commands");
   while(1) {
     //escape
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,53)) {
@@ -93,7 +96,13 @@ void discover_drone() {
       NSLog(@"Landing");
       break;
     }
-    //faster
+    //F - flat trim
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,3)) {
+      NSLog(@"Flat trim");
+      [MDDC userRequestedFlatTrim];
+      [NSThread sleepForTimeInterval:0.25];
+    }
+    //+ - faster
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,24)) {
       if(speed < 1.0) {
 	speed += 0.1;
@@ -101,7 +110,7 @@ void discover_drone() {
       }
       [NSThread sleepForTimeInterval:0.25];
     }
-    //slower
+    //- - slower
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,27)) {
       if(speed >= 0.1) {
 	speed -= 0.1;
@@ -109,54 +118,76 @@ void discover_drone() {
       }
       [NSThread sleepForTimeInterval:0.25];
     }
-    //up
+    //space - land or takeoff
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,49)) {
+      if(land == 1) {
+	NSLog(@"Landing");
+	[MDDC userRequestedLanding];
+	[NSThread sleepForTimeInterval:1];
+	land = 0;
+      } else {
+	NSLog(@"Taking Off");
+	[MDDC userRequestedTakeOff];
+	[NSThread sleepForTimeInterval:1];
+	[MDDC userRequestedFlatTrim];
+	[NSThread sleepForTimeInterval:0.25];
+	land = 1;
+      }
+    }
+    //enter key - photo
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,36)) {
+      NSLog(@"Taking Photo");
+      [MDDC userRequestedRecordPicture:1];
+      [NSThread sleepForTimeInterval:1.0];
+    }
+    //up arrow - tilt forward
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,126)) {
       commandFound = 1;
-      NSLog(@"Going Up");
-      [MDDC userGazChanged:speed];
+      NSLog(@"Tilting Forwards");
+      [MDDC userPitchChanged:speed*0.5];
     }
-    //down
+    //back arrow - tilt backwards
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,125)) {
       commandFound = 1;
-      NSLog(@"Going Down");
-      [MDDC userGazChanged:-speed];
+      NSLog(@"Tilting Backwards");
+      [MDDC userPitchChanged:-speed*0.5];
     }
-    //rotate right
-    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,2)) {
+    //right arrow - rotate right
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,124)) {
       commandFound = 1;
       NSLog(@"Rotating Right");
       [MDDC userYawChanged:speed];
     }
-    //rotate left
-    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,0)) {
+    //left arrow - rotate left
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,123)) {
       commandFound = 1;
       NSLog(@"Rotating Left");
       [MDDC userYawChanged:-speed];
     }
 
-    //tilt forward
+    //W - up
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,13)) {
       commandFound = 1;
-      NSLog(@"Tilting Forwards");
-      [MDDC userPitchChanged:speed];
+      NSLog(@"Going Up");
+      [MDDC userGazChanged:speed*0.5];
     }
-    //tilt backwards
+    //S - down
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,1)) {
       commandFound = 1;
-      NSLog(@"Tilting Backwards");
-      [MDDC userPitchChanged:-speed];
+      NSLog(@"Going Down");
+      [MDDC userGazChanged:-speed*0.5];
     }
-    //roll right
-    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,124)) {
+    //D - roll right
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,2)) {
       commandFound = 1;
       NSLog(@"Rolling Right");
-      [MDDC userRollChanged:speed];
+      [MDDC userRollChanged:speed*0.5];
     }
-    //roll left
-    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,123)) {
+    //A - roll left
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,0)) {
       commandFound = 1;
       NSLog(@"Rolling Left");
-      [MDDC userRollChanged:-speed];
+      [MDDC userRollChanged:-speed*0.5];
     }
     
     if(commandFound) {
@@ -168,7 +199,7 @@ void discover_drone() {
       [MDDC userPitchChanged:0];
       [MDDC userRollChanged:0];
     }
-    [NSThread sleepForTimeInterval:0.1];
+    [NSThread sleepForTimeInterval:0.15];
   }
   
   [MDDC userRequestedLanding];

--- a/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
+++ b/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+
 #import <libARDiscovery/ARDISCOVERY_BonjourDiscovery.h>
 #import <libARSAL/ARSAL.h>
 #import <libARNetwork/ARNetwork.h>
@@ -11,6 +13,18 @@ static const char* TAG = "DeviceController";
 void discover_drone() {
   ARService *foundService = nil;
   ARDiscovery *ARD = [ARDiscovery sharedInstance];
+
+  /*
+  int j;
+  while(1) {
+    int i;
+    for(i = 0; i < 128; i++) {
+      if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,i)) {
+	NSLog(@"keypressed %d", i);
+      }
+    }
+  }
+  */
 
   while(foundService == nil) {
     [NSThread sleepForTimeInterval:1];
@@ -36,41 +50,163 @@ void discover_drone() {
   MiniDroneDeviceController *MDDC = [[MiniDroneDeviceController alloc] initWithService:foundService];
   NSLog(@"Initialized MiniDroneDeviceController");
   [MDDC start];
-  [NSThread sleepForTimeInterval:5];
   NSLog(@"MDDC Started");
 
+  // meter/sec - min: 0.5, max: 2.5
+  [MDDC userRequestedSpeedSettingsMaxVerticalSpeed:1.0];
+  [NSThread sleepForTimeInterval:0.3];
+
+  //degree - min: 5, max: 25
+  [MDDC userRequestedPilotingSettingsMaxTilt:15.0];
+  [NSThread sleepForTimeInterval:0.3];
+
+  //degree/sec - min: 50, max: 360
+  [MDDC userRequestedSpeedSettingsMaxRotationSpeed:150.0];
+  [NSThread sleepForTimeInterval:0.3];
+
+  //Activate ability to tilt
+  [MDDC userCommandsActivationChanged:1];
+  [NSThread sleepForTimeInterval:0.3];
+
+  //Turn off wheels
+  [MDDC userRequestedSpeedSettingsWheels:0];
+  [NSThread sleepForTimeInterval:0.3];
+
+  //Reset state of drone (maybe unnecessary)
+  [MDDC controllerLoop];
+  [NSThread sleepForTimeInterval:0.3];
+  
+  [MDDC userRequestedFlatTrim];
+  [NSThread sleepForTimeInterval:0.3];
+ 
   NSLog(@"Blink Blink");
   [MDDC userRequestSetAutoTakeOffMode:1];
-  [NSThread sleepForTimeInterval:2];
+  [NSThread sleepForTimeInterval:0.3];
 
-  [MDDC userRequestSetAutoTakeOffMode:0];
-  [NSThread sleepForTimeInterval:2];
-
-  //[MDDC userGazChanged:2.0];
-  //[MDDC controllerLoop];
-  //[NSThread sleepForTimeInterval:2];
-
-  //[MDDC userGazChanged:0.0];
-  //[MDDC controllerLoop];
-  //[NSThread sleepForTimeInterval:2];
+  float speed = 0.50;
   
-  //[MDDC userRequestedLanding];
-  //[NSThread sleepForTimeInterval:2];
+  int commandFound = 0;
+  while(1) {
+    //escape
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,53)) {
+      commandFound = 1;
+      NSLog(@"Landing");
+      break;
+    }
+    //faster
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,24)) {
+      if(speed < 1.0) {
+	speed += 0.1;
+	NSLog(@"Speeding Up %f", speed);
+      }
+      [NSThread sleepForTimeInterval:0.25];
+    }
+    //slower
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,27)) {
+      if(speed >= 0.1) {
+	speed -= 0.1;
+	NSLog(@"Speeding Down %f", speed);
+      }
+      [NSThread sleepForTimeInterval:0.25];
+    }
+    //up
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,126)) {
+      commandFound = 1;
+      NSLog(@"Going Up");
+      [MDDC userGazChanged:speed];
+    }
+    //down
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,125)) {
+      commandFound = 1;
+      NSLog(@"Going Down");
+      [MDDC userGazChanged:-speed];
+    }
+    //rotate right
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,2)) {
+      commandFound = 1;
+      NSLog(@"Rotating Right");
+      [MDDC userYawChanged:speed];
+    }
+    //rotate left
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,0)) {
+      commandFound = 1;
+      NSLog(@"Rotating Left");
+      [MDDC userYawChanged:-speed];
+    }
+
+    //tilt forward
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,13)) {
+      commandFound = 1;
+      NSLog(@"Tilting Forwards");
+      [MDDC userPitchChanged:speed];
+    }
+    //tilt backwards
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,1)) {
+      commandFound = 1;
+      NSLog(@"Tilting Backwards");
+      [MDDC userPitchChanged:-speed];
+    }
+    //roll right
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,124)) {
+      commandFound = 1;
+      NSLog(@"Rolling Right");
+      [MDDC userRollChanged:speed];
+    }
+    //roll left
+    if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,123)) {
+      commandFound = 1;
+      NSLog(@"Rolling Left");
+      [MDDC userRollChanged:-speed];
+    }
+    
+    if(commandFound) {
+      [MDDC controllerLoop];
+      commandFound = 0;
+
+      [MDDC userGazChanged:0];
+      [MDDC userYawChanged:0];
+      [MDDC userPitchChanged:0];
+      [MDDC userRollChanged:0];
+    }
+    [NSThread sleepForTimeInterval:0.1];
+  }
+  
+  [MDDC userRequestedLanding];
+  [NSThread sleepForTimeInterval:2];
   
   [MDDC stop];
   [NSThread sleepForTimeInterval:5];
-  NSLog(@"MDDC Stopped...or rather, brought to a screeching hault");
+  NSLog(@"MDDC Stopped");
   
   exit(0);
 }
 
 int main() {
   @autoreleasepool {
-    ARDiscovery *ARD = [ARDiscovery sharedInstance];
-    [ARD start];
-
     dispatch_queue_t my_main_thread = dispatch_queue_create("MyMainThread", NULL);
-    dispatch_async(my_main_thread, ^{ discover_drone(); });
+
+    /*
+    dispatch_async(my_main_thread,^{
+    	NSNotificationCenter *mainCenter = [NSNotificationCenter defaultCenter];
+	[mainCenter postNotificationName:@"my_notification" object:nil];
+
+	[[NSDistributedNotificationCenter defaultCenter] addObserverForName:nil object:nil queue:nil usingBlock:^(NSNotification *notification)
+							 {
+							   NSLog(@"%@", notification);
+							 }];
+      });
+    */
+
+    dispatch_async(my_main_thread,^{
+	ARDiscovery *ARD = [ARDiscovery sharedInstance];
+	[ARD start];
+	discover_drone();
+      });
+    
+    dispatch_async(my_main_thread, ^{
+	[NSThread sleepForTimeInterval:5];
+	discover_drone();
+      });
 
     [[NSRunLoop currentRunLoop] run];
   }

--- a/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
+++ b/Contributions/OSX/RollingSpiderCruft/RollingSpiderTest.m
@@ -76,9 +76,6 @@ void discover_drone() {
   [MDDC controllerLoop];
   [NSThread sleepForTimeInterval:0.3];
   
-  [MDDC userRequestedFlatTrim];
-  [NSThread sleepForTimeInterval:0.3];
- 
   //NSLog(@"Blink Blink");
   //[MDDC userRequestSetAutoTakeOffMode:1];
   //[NSThread sleepForTimeInterval:0.3];
@@ -127,6 +124,8 @@ void discover_drone() {
 	land = 0;
       } else {
 	NSLog(@"Taking Off");
+	[MDDC userRequestedFlatTrim];
+	[NSThread sleepForTimeInterval:0.25];
 	[MDDC userRequestedTakeOff];
 	[NSThread sleepForTimeInterval:1];
 	[MDDC userRequestedFlatTrim];
@@ -137,6 +136,7 @@ void discover_drone() {
     //enter key - photo
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,36)) {
       NSLog(@"Taking Photo");
+      [NSThread sleepForTimeInterval:0.25];
       [MDDC userRequestedRecordPicture:1];
       [NSThread sleepForTimeInterval:1.0];
     }

--- a/Contributions/OSX/RollingSpiderOK/DeviceController.h
+++ b/Contributions/OSX/RollingSpiderOK/DeviceController.h
@@ -1,0 +1,105 @@
+/*
+    Copyright (C) 2014 Parrot SA
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Parrot nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+*/
+//
+//  DeviceController.h
+//  RollingSpiderPiloting
+//
+//  Created on 20/01/2015.
+//  Copyright (c) 2015 Parrot. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import <libARSAL/ARSAL.h>
+#import <libARDiscovery/ARDiscovery.h>
+#import <libARDiscovery/ARDISCOVERY_BonjourDiscovery.h>
+#import <libARCommands/ARCommands.h>
+#import <libARNetwork/ARNetwork.h>
+#import <libARNetworkAL/ARNetworkAL.h>
+
+typedef struct
+{
+    uint8_t flag; // [0;1] flag to activate roll/pitch movement
+    float roll; // [-1;1]
+    float pitch; // [-1;1]
+    float yaw; // [-1;1]
+    float gaz; // [-1;1]
+    float psi; // [-360;360]
+}RS_PCMD_t;
+
+typedef struct
+{
+    void *deviceController;
+    int readerBufferId;
+}READER_THREAD_DATA_t;
+
+
+
+@class DeviceController;
+
+@protocol DeviceControllerDelegate <NSObject>
+- (void)onDisconnectNetwork:(DeviceController *)deviceController;
+- (void)onUpdateBattery:(DeviceController *)deviceController batteryLevel:(uint8_t)percent;
+@end
+
+
+@interface DeviceController : NSObject
+
+@property (nonatomic, weak) id <DeviceControllerDelegate> delegate;
+/** Get the ARService instance associated with this controller. */
+@property (readonly, nonatomic, strong) ARService* service;
+
+- (id)initWithARService:(ARService*)service;
+- (BOOL)start;
+- (void)stop;
+
+- (BOOL) sendFlatTrim;
+- (BOOL) sendAutoTakeoff:(uint8_t)state;
+- (BOOL) sendTakeoff;
+- (BOOL) sendLanding;
+- (BOOL) sendEmergency;
+- (BOOL) sendAnimationsFlip:(eARCOMMANDS_MINIDRONE_ANIMATIONS_FLIP_DIRECTION)direction;
+- (BOOL) sendAnimationsCap:(int16_t)offset;
+- (BOOL) sendMediaRecordPicture:(uint8_t)mass_storage_id;
+- (BOOL) sendMaxAltitude:(float)current;
+- (BOOL) sendMaxTilt:(float)current;
+- (BOOL) sendMaxVerticalSpeed:(float)current;
+- (BOOL) sendMaxRotationSpeed:(float)current;
+- (BOOL) sendWheelsOn:(uint8_t)present;
+- (BOOL) sendCutOutMode:(uint8_t)enable;
+					
+- (void) setRoll:(float)roll;
+- (void) setPitch:(float)pitch;
+- (void) setYaw:(float)yaw;
+- (void) setGaz:(float)gaz;
+- (void) setFlag:(uint8_t)flag;
+
+@end
+

--- a/Contributions/OSX/RollingSpiderOK/DeviceController.h
+++ b/Contributions/OSX/RollingSpiderOK/DeviceController.h
@@ -75,8 +75,10 @@ typedef struct
 @property (nonatomic, weak) id <DeviceControllerDelegate> delegate;
 /** Get the ARService instance associated with this controller. */
 @property (readonly, nonatomic, strong) ARService* service;
-
-- (id)initWithARService:(ARService*)service;
+@property (readonly, nonatomic, strong) CBPeripheral* peripheral;
+@property (readonly, nonatomic, strong) ARDiscovery *ARD;
+					
+- (id)init;
 - (BOOL)start;
 - (void)stop;
 

--- a/Contributions/OSX/RollingSpiderOK/DeviceController.m
+++ b/Contributions/OSX/RollingSpiderOK/DeviceController.m
@@ -1,0 +1,1026 @@
+/*
+    Copyright (C) 2014 Parrot SA
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the 
+      distribution.
+    * Neither the name of Parrot nor the names
+      of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED 
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+    OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+*/
+//
+//  DeviceController.m
+//  RollingSpiderPiloting
+//
+//  Created by  20/01/2015.
+//  Copyright (c) 2015 Parrot. All rights reserved.
+//
+
+#import "DeviceController.h"
+
+#import <libARSAL/ARSAL.h>
+#import <libARNetwork/ARNetwork.h>
+#import <libARNetworkAL/ARNetworkAL.h>
+#import <libARCommands/ARCommands.h>
+
+static const char* TAG = "DeviceController";
+
+static const int RS_NET_C2D_NONACK = 10;
+static const int RS_NET_C2D_ACK = 11;
+static const int RS_NET_C2D_EMERGENCY = 12;
+static const int RS_NET_D2C_NAVDATA = (ARNETWORKAL_MANAGER_BLE_ID_MAX / 2) - 1;
+static const int RS_NET_D2C_EVENTS = (ARNETWORKAL_MANAGER_BLE_ID_MAX / 2) - 2;
+
+static int BLE_NOTIFICATION_IDS[] = {
+    RS_NET_D2C_NAVDATA,
+    RS_NET_D2C_EVENTS,
+    (RS_NET_C2D_ACK + (ARNETWORKAL_MANAGER_BLE_ID_MAX / 2)),
+    (RS_NET_C2D_EMERGENCY + (ARNETWORKAL_MANAGER_BLE_ID_MAX / 2)),
+};
+static const size_t NB_OF_BLE_NOTIFICATION_IDS = sizeof(BLE_NOTIFICATION_IDS) / sizeof(int);
+
+static ARNETWORK_IOBufferParam_t C2D_PARAMS[] = {
+    {
+        .ID = RS_NET_C2D_NONACK,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = -1,
+        .numberOfRetry = -1,
+        .numberOfCell = 1,
+        .dataCopyMaxSize = ARNETWORK_IOBUFFERPARAM_DATACOPYMAXSIZE_USE_MAX,
+        .isOverwriting = 1,
+    },
+    {
+        .ID = RS_NET_C2D_ACK,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = 500,
+        .numberOfRetry = 3,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = ARNETWORK_IOBUFFERPARAM_DATACOPYMAXSIZE_USE_MAX,
+        .isOverwriting = 0,
+    },
+    {
+        .ID = RS_NET_C2D_EMERGENCY,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 1,
+        .ackTimeoutMs = 100,
+        .numberOfRetry = ARNETWORK_IOBUFFERPARAM_INFINITE_NUMBER,
+        .numberOfCell = 1,
+        .dataCopyMaxSize = ARNETWORK_IOBUFFERPARAM_DATACOPYMAXSIZE_USE_MAX,
+        .isOverwriting = 0,
+    }
+};
+static const size_t NUM_OF_C2D_PARAMS = sizeof(C2D_PARAMS) / sizeof(ARNETWORK_IOBufferParam_t);
+
+static ARNETWORK_IOBufferParam_t D2C_PARAMS[] = {
+    {
+        .ID = RS_NET_D2C_NAVDATA,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = -1,
+        .numberOfRetry = -1,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = ARNETWORK_IOBUFFERPARAM_DATACOPYMAXSIZE_USE_MAX,
+        .isOverwriting = 0,
+    },
+    {
+        .ID = RS_NET_D2C_EVENTS,
+        .dataType = ARNETWORKAL_FRAME_TYPE_DATA_WITH_ACK,
+        .sendingWaitTimeMs = 20,
+        .ackTimeoutMs = 500,
+        .numberOfRetry = 3,
+        .numberOfCell = 20,
+        .dataCopyMaxSize = ARNETWORK_IOBUFFERPARAM_DATACOPYMAXSIZE_USE_MAX,
+        .isOverwriting = 0,
+    }
+};
+static const size_t NUM_OF_D2C_PARAMS = sizeof(D2C_PARAMS) / sizeof(ARNETWORK_IOBufferParam_t);
+
+static int COMMAND_BUFFER_IDS[] = {
+    RS_NET_D2C_NAVDATA,
+    RS_NET_D2C_EVENTS,
+};
+static const size_t NUM_OF_COMMANDS_BUFFER_IDS = sizeof(COMMAND_BUFFER_IDS) / sizeof(int);
+
+@interface DeviceController ()
+
+@property (nonatomic, assign) ARNETWORKAL_Manager_t *alManager;
+@property (nonatomic, assign) ARNETWORK_Manager_t *netManager;
+@property (nonatomic) ARSAL_Thread_t rxThread;
+@property (nonatomic) ARSAL_Thread_t txThread;
+@property (nonatomic) int c2dPort;
+@property (nonatomic) int d2cPort;
+
+@property (nonatomic) ARSAL_Thread_t looperThread;
+@property (nonatomic) ARSAL_Thread_t *readerThreads;
+@property (nonatomic) READER_THREAD_DATA_t *readerThreadsData;
+
+@property (nonatomic) BOOL run;
+@property (nonatomic) BOOL alManagerInitialized;
+
+@property (nonatomic) RS_PCMD_t dataPCMD;
+
+@end
+
+@implementation DeviceController
+
+- (id)initWithARService:(ARService*)service
+{
+    self = [super init];
+    if (self)
+    {
+        _service = service;
+        
+        // initialize deviceManager
+        _alManager = NULL;
+        _netManager = NULL;
+        _rxThread = NULL;
+        _txThread = NULL;
+        
+        _looperThread = NULL;
+        _readerThreads = NULL;
+        _readerThreadsData = NULL;
+        
+        _run = YES;
+        _alManagerInitialized = NO;
+        
+        _dataPCMD.flag = 0;
+        _dataPCMD.roll = 0;
+        _dataPCMD.pitch = 0;
+        _dataPCMD.yaw = 0;
+        _dataPCMD.gaz = 0;
+        _dataPCMD.psi = 0;
+        
+    }
+    
+    return self;
+}
+
+- (void)dealloc
+{
+
+}
+
+- (BOOL)start
+{
+    NSLog(@"start ...");
+    
+    BOOL failed = NO;
+    
+    [self registerARCommandsCallbacks];
+    
+    failed = [self startNetwork];
+    
+    if (!failed)
+    {
+        // Create and start looper thread.
+        if (ARSAL_Thread_Create(&(_looperThread), looperRun, (__bridge void *)self) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of looper thread failed.");
+            failed = YES;
+        }
+    }
+    
+    if (!failed)
+    {
+        // allocate reader thread array.
+        _readerThreads = calloc(NUM_OF_COMMANDS_BUFFER_IDS, sizeof(ARSAL_Thread_t));
+        
+        if (_readerThreads == NULL)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Allocation of reader threads failed.");
+            failed = YES;
+        }
+    }
+    
+    if (!failed)
+    {
+        // allocate reader thread data array.
+        _readerThreadsData = calloc(NUM_OF_COMMANDS_BUFFER_IDS, sizeof(READER_THREAD_DATA_t));
+        
+        if (_readerThreadsData == NULL)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Allocation of reader threads data failed.");
+            failed = YES;
+        }
+    }
+    
+    if (!failed)
+    {
+        // Create and start reader threads.
+        int readerThreadIndex = 0;
+        for (readerThreadIndex = 0 ; readerThreadIndex < NUM_OF_COMMANDS_BUFFER_IDS ; readerThreadIndex++)
+        {
+            // initialize reader thread data
+            _readerThreadsData[readerThreadIndex].deviceController = (__bridge void *)self;
+            _readerThreadsData[readerThreadIndex].readerBufferId = COMMAND_BUFFER_IDS[readerThreadIndex];
+            
+            if (ARSAL_Thread_Create(&(_readerThreads[readerThreadIndex]), readerRun, &(_readerThreadsData[readerThreadIndex])) != 0)
+            {
+                ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of reader thread failed.");
+                failed = YES;
+            }
+        }
+    }
+    
+    return failed;
+}
+
+- (BOOL)startNetwork
+{
+    BOOL failed = NO;
+    eARNETWORK_ERROR netError = ARNETWORK_OK;
+    eARNETWORKAL_ERROR netAlError = ARNETWORKAL_OK;
+    int pingDelay = 0; // 0 means default, -1 means no ping
+    
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Start ARNetwork");
+    
+    // Create the ARNetworkALManager
+    _alManager = ARNETWORKAL_Manager_New(&netAlError);
+    if (netAlError != ARNETWORKAL_OK)
+    {
+        failed = YES;
+    }
+    
+    if (!failed)
+    {
+      if ([_service.service isKindOfClass:[ARBLEService class]]) {
+	// Setup ARNetworkAL for BLE.
+	ARBLEService* bleService = _service.service;
+        netAlError = ARNETWORKAL_Manager_InitBLENetwork(_alManager, (__bridge ARNETWORKAL_BLEDeviceManager_t)(bleService.centralManager), (__bridge ARNETWORKAL_BLEDevice_t)(bleService.peripheral), 1, BLE_NOTIFICATION_IDS,NB_OF_BLE_NOTIFICATION_IDS);
+        if (netAlError != ARNETWORKAL_OK)
+	  {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNETWORKAL_Manager_InitBLENetwork() failed. %s", ARNETWORKAL_Error_ToString(netAlError));
+            failed = YES;
+	  }
+        else
+	  {
+            _alManagerInitialized = YES;
+            pingDelay = -1; // Disable ping for BLE networks
+	  }
+      } else {
+	failed = YES;
+      }
+    }
+
+    if (!failed)
+    {
+        // Create the ARNetworkManager.
+        _netManager = ARNETWORK_Manager_New(_alManager, NUM_OF_C2D_PARAMS, C2D_PARAMS, NUM_OF_D2C_PARAMS, D2C_PARAMS, pingDelay, onDisconnectNetwork, (__bridge void *)self, &netError);
+        if (netError != ARNETWORK_OK)
+        {
+            failed = YES;
+        }
+    }
+    
+    if (!failed)
+    {
+        // Create and start Tx and Rx threads.
+        if (ARSAL_Thread_Create(&(_rxThread), ARNETWORK_Manager_ReceivingThreadRun, _netManager) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of Rx thread failed.");
+            failed = YES;
+        }
+        
+        if (ARSAL_Thread_Create(&(_txThread), ARNETWORK_Manager_SendingThreadRun, _netManager) != 0)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "Creation of Tx thread failed.");
+            failed = YES;
+        }
+    }
+    
+    // Print net error
+    if (failed)
+    {
+        if (netAlError != ARNETWORKAL_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNetWorkAL Error : %s", ARNETWORKAL_Error_ToString(netAlError));
+        }
+        
+        if (netError != ARNETWORK_OK)
+        {
+            ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNetWork Error : %s", ARNETWORK_Error_ToString(netError));
+        }
+    } else {
+      //Send date and time, necessary for reconnect
+      NSLog(@"Sending Current Date");
+      [self sendCurrentDate];
+      NSLog(@"Sending Current Time");
+      [self sendCurrentTime];
+    }
+    
+    return failed;
+}
+
+- (void)stop
+{
+    NSLog(@"stop ...");
+    
+    _run = NO; // break threads loops
+    
+    [self unregisterARCommandsCallbacks];
+    
+    // Stop looper Thread
+    if (_looperThread != NULL)
+    {
+        ARSAL_Thread_Join(_looperThread, NULL);
+        ARSAL_Thread_Destroy(&(_looperThread));
+        _looperThread = NULL;
+    }
+    
+    if (_readerThreads != NULL)
+    {
+        // Stop reader Threads
+        int readerThreadIndex = 0;
+        for (readerThreadIndex = 0 ; readerThreadIndex < NUM_OF_D2C_PARAMS ; readerThreadIndex++)
+        {
+            if (_readerThreads[readerThreadIndex] != NULL)
+            {
+                ARSAL_Thread_Join(_readerThreads[readerThreadIndex], NULL);
+                ARSAL_Thread_Destroy(&(_readerThreads[readerThreadIndex]));
+                _readerThreads[readerThreadIndex] = NULL;
+            }
+        }
+        
+        // free reader thread array
+        free (_readerThreads);
+        _readerThreads = NULL;
+    }
+    
+    if (_readerThreadsData != NULL)
+    {
+        // free reader thread data array
+        free (_readerThreadsData);
+        _readerThreadsData = NULL;
+    }
+    
+    // Stop Network
+    [self stopNetwork];
+}
+
+- (void)stopNetwork
+{
+    ARSAL_PRINT(ARSAL_PRINT_INFO, TAG, "- Stop ARNetwork");
+    
+    // ARNetwork cleanup
+    if (_netManager != NULL)
+    {
+        ARNETWORK_Manager_Stop(_netManager);
+        if (_rxThread != NULL)
+        {
+            ARSAL_Thread_Join(_rxThread, NULL);
+            ARSAL_Thread_Destroy(&(_rxThread));
+            _rxThread = NULL;
+        }
+        
+        if (_txThread != NULL)
+        {
+            ARSAL_Thread_Join(_txThread, NULL);
+            ARSAL_Thread_Destroy(&(_txThread));
+            _txThread = NULL;
+        }
+    }
+    
+    if ((_alManager != NULL) && (_alManagerInitialized == YES))
+    {
+        ARNETWORKAL_Manager_Unlock(_alManager);
+        
+        ARNETWORKAL_Manager_CloseBLENetwork(_alManager);
+    }
+    
+    ARNETWORK_Manager_Delete(&(_netManager));
+    ARNETWORKAL_Manager_Delete(&(_alManager));
+}
+
+- (BOOL) sendPCMD
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    if(_dataPCMD.roll != 0 ||
+       _dataPCMD.pitch != 0 ||
+       _dataPCMD.yaw != 0 ||
+       _dataPCMD.gaz != 0) {
+    /*
+    NSLog(@"====> %d, %d, %d, %d, %d, %f",
+	  (uint8_t)(_dataPCMD.flag),
+	  (int8_t)(_dataPCMD.roll * 100.f),
+	  (int8_t)(_dataPCMD.pitch * 100.f),
+	  (int8_t)(_dataPCMD.yaw * 100.f),
+	  (int8_t)(_dataPCMD.gaz * 100.f),
+	  _dataPCMD.psi);
+    */
+    
+    // Send Posture command
+      cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingPCMD(cmdBuffer, sizeof(cmdBuffer), &cmdSize, _dataPCMD.flag, _dataPCMD.roll*100.f, _dataPCMD.pitch*100.f, _dataPCMD.yaw*100.f, _dataPCMD.gaz*100.f, _dataPCMD.psi);
+      if (cmdError == ARCOMMANDS_GENERATOR_OK)
+	{
+	  // The commands sent in loop should be sent to a buffer not acknowledged ; here JS_NET_CD_NONACK_ID
+	  netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_NONACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+	}
+      
+      if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+	{
+	  sentStatus = NO;
+	}
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendFlatTrim
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingFlatTrim(cmdBuffer, sizeof(cmdBuffer), &cmdSize);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendAutoTakeoff:(uint8_t)state
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingAutoTakeOffMode(cmdBuffer, sizeof(cmdBuffer), &cmdSize, state);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendTakeoff
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingTakeOff(cmdBuffer, sizeof(cmdBuffer), &cmdSize);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendLanding
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingLanding(cmdBuffer, sizeof(cmdBuffer), &cmdSize);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendEmergency
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingEmergency(cmdBuffer, sizeof(cmdBuffer), &cmdSize);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The command emergency should be sent to its own buffer acknowledged  ; here RS_NET_C2D_EMERGENCY
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_EMERGENCY, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendAnimationsFlip:(eARCOMMANDS_MINIDRONE_ANIMATIONS_FLIP_DIRECTION)direction
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneAnimationsFlip(cmdBuffer, sizeof(cmdBuffer), &cmdSize, direction);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendAnimationsCap:(int16_t)offset
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneAnimationsCap(cmdBuffer, sizeof(cmdBuffer), &cmdSize, offset);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendMediaRecordPicture:(uint8_t)mass_storage_id
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneMediaRecordPicture(cmdBuffer, sizeof(cmdBuffer), &cmdSize, mass_storage_id);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendMaxAltitude:(float)current
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingSettingsMaxAltitude(cmdBuffer, sizeof(cmdBuffer), &cmdSize, current);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendMaxTilt:(float)current
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingSettingsMaxTilt(cmdBuffer, sizeof(cmdBuffer), &cmdSize, current);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendMaxVerticalSpeed:(float)current
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneSpeedSettingsMaxVerticalSpeed(cmdBuffer, sizeof(cmdBuffer), &cmdSize, current);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendMaxRotationSpeed:(float)current
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneSpeedSettingsMaxRotationSpeed(cmdBuffer, sizeof(cmdBuffer), &cmdSize, current);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendWheelsOn:(uint8_t)present
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneSpeedSettingsWheels(cmdBuffer, sizeof(cmdBuffer), &cmdSize, present);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendCutOutMode:(uint8_t)enable
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+    
+    // Send Posture command
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDroneSettingsCutOutMode(cmdBuffer, sizeof(cmdBuffer), &cmdSize, enable);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendCurrentDate
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+
+    NSDate *currentDate = [NSDate date];
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setTimeZone:[NSTimeZone systemTimeZone]];
+    [dateFormatter setLocale:[NSLocale systemLocale]];
+    // Set date
+    [dateFormatter setDateFormat:@"yyyy-MM-dd"];
+    
+    // Send Date command
+    cmdError = ARCOMMANDS_Generator_GenerateCommonCommonCurrentDate(cmdBuffer, sizeof(cmdBuffer), &cmdSize, (char *)[[dateFormatter stringFromDate:currentDate] cStringUsingEncoding:NSUTF8StringEncoding]);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+
+- (BOOL) sendCurrentTime
+{
+    BOOL sentStatus = YES;
+    u_int8_t cmdBuffer[128];
+    int32_t cmdSize = 0;
+    eARCOMMANDS_GENERATOR_ERROR cmdError;
+    eARNETWORK_ERROR netError = ARNETWORK_ERROR;
+
+    NSDate *currentDate = [NSDate date];
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setTimeZone:[NSTimeZone systemTimeZone]];
+    [dateFormatter setLocale:[NSLocale systemLocale]];
+    // Set time
+    [dateFormatter setDateFormat:@"'T'HHmmssZZZ"];
+    
+    // Send Time command
+    cmdError = ARCOMMANDS_Generator_GenerateCommonCommonCurrentTime(cmdBuffer, sizeof(cmdBuffer), &cmdSize, (char *)[[dateFormatter stringFromDate:currentDate] cStringUsingEncoding:NSUTF8StringEncoding]);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+    {
+        // The commands sent by event should be sent to an buffer acknowledged  ; here RS_NET_C2D_ACK
+        netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_ACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+    }
+    
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+    {
+        sentStatus = NO;
+    }
+    
+    return sentStatus;
+}
+ 
+-(void) registerARCommandsCallbacks
+{
+    ARCOMMANDS_Decoder_SetCommonCommonStateBatteryStateChangedCallback(batteryStateChangedCallback, (__bridge void *)self);
+}
+
+-(void) unregisterARCommandsCallbacks
+{
+    ARCOMMANDS_Decoder_SetCommonCommonStateBatteryStateChangedCallback (NULL, NULL);
+}
+
+/**
+ * @brief fuction called on disconnect
+ * @param manager The manager
+ */
+void onDisconnectNetwork (ARNETWORK_Manager_t *manager, ARNETWORKAL_Manager_t *alManager, void *customData)
+{
+    if(customData != NULL) {
+      DeviceController *deviceController = (__bridge DeviceController*)customData;
+    
+      NSLog(@"onDisconnectNetwork ... %@ : %@", deviceController, [deviceController delegate]);
+      
+      if ((deviceController != nil) && (deviceController.delegate != nil))
+	{
+	  [deviceController.delegate onDisconnectNetwork:deviceController];
+	}
+
+      [deviceController stop];
+    }
+}
+
+void *looperRun (void* data)
+{
+    //DEVICE_MANAGER_t *deviceManager = (DEVICE_MANAGER_t *)data;
+    DeviceController *deviceController = (__bridge DeviceController*)data;
+    
+    if(deviceController != NULL)
+    {
+        while (deviceController.run)
+        {
+            [deviceController sendPCMD];
+	    usleep(50000);
+        }
+    }
+    
+    return NULL;
+}
+
+void *readerRun (void* data)
+{
+    DeviceController *deviceController = NULL;
+    int bufferId = 0;
+    int failed = 0;
+    
+    // Allocate some space for incoming data.
+    const size_t maxLength = 128 * 1024;
+    void *readData = malloc (maxLength);
+    if (readData == NULL)
+    {
+        failed = 1;
+    }
+    
+    if (!failed)
+    {
+        // get thread data.
+        if (data != NULL)
+        {
+            bufferId = ((READER_THREAD_DATA_t *)data)->readerBufferId;
+            deviceController = (__bridge DeviceController*)((READER_THREAD_DATA_t *)data)->deviceController;
+            
+            if (deviceController == NULL)
+            {
+                failed = 1;
+            }
+        }
+        else
+        {
+            failed = 1;
+        }
+    }
+    
+    if (!failed)
+    {
+        while (deviceController.run)
+        {
+            eARNETWORK_ERROR netError = ARNETWORK_OK;
+            int length = 0;
+            int skip = 0;
+            
+            // read data
+            netError = ARNETWORK_Manager_ReadDataWithTimeout (deviceController.netManager, bufferId, readData, maxLength, &length, 1000);
+            if (netError != ARNETWORK_OK)
+            {
+                if (netError != ARNETWORK_ERROR_BUFFER_EMPTY)
+                {
+                    ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARNETWORK_Manager_ReadDataWithTimeout () failed : %s", ARNETWORK_Error_ToString(netError));
+                }
+                skip = 1;
+            }
+            
+            if (!skip)
+            {
+                // Forward data to the CommandsManager
+                eARCOMMANDS_DECODER_ERROR cmdError = ARCOMMANDS_DECODER_OK;
+                cmdError = ARCOMMANDS_Decoder_DecodeBuffer ((uint8_t *)readData, length);
+                if ((cmdError != ARCOMMANDS_DECODER_OK) && (cmdError != ARCOMMANDS_DECODER_ERROR_NO_CALLBACK))
+                {
+                    char msg[128];
+                    ARCOMMANDS_Decoder_DescribeBuffer ((uint8_t *)readData, length, msg, sizeof(msg));
+                    ARSAL_PRINT(ARSAL_PRINT_ERROR, TAG, "ARCOMMANDS_Decoder_DecodeBuffer () failed : %d %s", cmdError, msg);
+                }
+            }
+        }
+    }
+    
+    if (readData != NULL)
+    {
+        free (readData);
+        readData = NULL;
+    }
+    
+    return NULL;
+}
+
+eARNETWORK_MANAGER_CALLBACK_RETURN arnetworkCmdCallback(int buffer_id, uint8_t *data, void *custom, eARNETWORK_MANAGER_CALLBACK_STATUS cause)
+{
+    eARNETWORK_MANAGER_CALLBACK_RETURN retval = ARNETWORK_MANAGER_CALLBACK_RETURN_DEFAULT;
+    
+    if (cause == ARNETWORK_MANAGER_CALLBACK_STATUS_TIMEOUT)
+    {
+        retval = ARNETWORK_MANAGER_CALLBACK_RETURN_DATA_POP;
+    }
+    
+    return retval;
+}
+
+void batteryStateChangedCallback (uint8_t percent, void *custom)
+{
+    // callback of changing of battery level
+    DeviceController *deviceController = (__bridge DeviceController*)custom;
+    
+    NSLog(@"batteryStateChangedCallback ... %d  ; %@ : %@", percent, deviceController, [deviceController delegate]);
+    
+    if ((deviceController != nil) && (deviceController.delegate != nil))
+    {
+        [deviceController.delegate onUpdateBattery:deviceController batteryLevel:percent];
+    }
+}
+
+- (void) setRoll:(float)roll
+{
+    _dataPCMD.roll = roll;
+}
+
+- (void) setPitch:(float)pitch
+{
+    _dataPCMD.pitch = pitch;
+}
+
+- (void) setYaw:(float)yaw
+{
+    _dataPCMD.yaw = yaw;
+}
+
+- (void) setGaz:(float)gaz
+{
+    _dataPCMD.gaz = gaz;
+}
+
+- (void) setFlag:(uint8_t)flag
+{
+    _dataPCMD.flag = flag;
+}
+
+@end

--- a/Contributions/OSX/RollingSpiderOK/DeviceController.m
+++ b/Contributions/OSX/RollingSpiderOK/DeviceController.m
@@ -421,12 +421,8 @@ static const size_t NUM_OF_COMMANDS_BUFFER_IDS = sizeof(COMMAND_BUFFER_IDS) / si
     eARCOMMANDS_GENERATOR_ERROR cmdError;
     eARNETWORK_ERROR netError = ARNETWORK_ERROR;
     
-    if(_dataPCMD.roll != 0 ||
-       _dataPCMD.pitch != 0 ||
-       _dataPCMD.yaw != 0 ||
-       _dataPCMD.gaz != 0) {
     /*
-    NSLog(@"====> %d, %d, %d, %d, %d, %f",
+      NSLog(@"====> %d, %d, %d, %d, %d, %f",
 	  (uint8_t)(_dataPCMD.flag),
 	  (int8_t)(_dataPCMD.roll * 100.f),
 	  (int8_t)(_dataPCMD.pitch * 100.f),
@@ -436,19 +432,18 @@ static const size_t NUM_OF_COMMANDS_BUFFER_IDS = sizeof(COMMAND_BUFFER_IDS) / si
     */
     
     // Send Posture command
-      cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingPCMD(cmdBuffer, sizeof(cmdBuffer), &cmdSize, _dataPCMD.flag, _dataPCMD.roll*100.f, _dataPCMD.pitch*100.f, _dataPCMD.yaw*100.f, _dataPCMD.gaz*100.f, _dataPCMD.psi);
-      if (cmdError == ARCOMMANDS_GENERATOR_OK)
-	{
-	  // The commands sent in loop should be sent to a buffer not acknowledged ; here JS_NET_CD_NONACK_ID
-	  netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_NONACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
-	}
-      
-      if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
-	{
-	  sentStatus = NO;
-	}
-    }
+    cmdError = ARCOMMANDS_Generator_GenerateMiniDronePilotingPCMD(cmdBuffer, sizeof(cmdBuffer), &cmdSize, _dataPCMD.flag, _dataPCMD.roll*100.f, _dataPCMD.pitch*100.f, _dataPCMD.yaw*100.f, _dataPCMD.gaz*100.f, _dataPCMD.psi);
+    if (cmdError == ARCOMMANDS_GENERATOR_OK)
+      {
+	// The commands sent in loop should be sent to a buffer not acknowledged ; here JS_NET_CD_NONACK_ID
+	netError = ARNETWORK_Manager_SendData(_netManager, RS_NET_C2D_NONACK, cmdBuffer, cmdSize, NULL, &(arnetworkCmdCallback), 1);
+      }
     
+    if ((cmdError != ARCOMMANDS_GENERATOR_OK) || (netError != ARNETWORK_OK))
+      {
+	sentStatus = NO;
+      }
+
     return sentStatus;
 }
 

--- a/Contributions/OSX/RollingSpiderOK/Makefile
+++ b/Contributions/OSX/RollingSpiderOK/Makefile
@@ -10,5 +10,8 @@ RSLIB=DeviceController.m
 RollingSpiderTest: RollingSpiderTest.m Makefile $(RSLIB)
 	clang -g -fobjc-arc $(LIBDIR) $(INCLUDES) $(LIBS) $(FRAMEWORKS) $(RSLIB) $< -o $@
 
+run: RollingSpiderTest
+	./RollingSpiderTest
+
 clean:
 	rm -rf RollingSpiderTest *.dSYM *~

--- a/Contributions/OSX/RollingSpiderOK/Makefile
+++ b/Contributions/OSX/RollingSpiderOK/Makefile
@@ -1,0 +1,14 @@
+LIBAR=../../../../ARSDKBuildUtils/Targets/Unix/Install
+
+FRAMEWORKS=-framework Foundation -framework CoreBluetooth -framework CoreGraphics
+INCLUDES=-I$(LIBAR)/include -I.
+LIBDIR=-L$(LIBAR)/lib
+LIBS=-lardiscovery -larnetworkal -larsal -larnetwork -larcommands
+
+RSLIB=DeviceController.m
+
+RollingSpiderTest: RollingSpiderTest.m Makefile $(RSLIB)
+	clang -g -fobjc-arc $(LIBDIR) $(INCLUDES) $(LIBS) $(FRAMEWORKS) $(RSLIB) $< -o $@
+
+clean:
+	rm -rf RollingSpiderTest *.dSYM *~

--- a/Contributions/OSX/RollingSpiderOK/RollingSpiderTest.m
+++ b/Contributions/OSX/RollingSpiderOK/RollingSpiderTest.m
@@ -6,9 +6,7 @@
 #import <libARNetwork/ARNetwork.h>
 #import <libARNetworkAL/ARNetworkAL.h>
 
-#import "RSlib/MiniDroneDeviceController.h"
-
-static const char* TAG = "DeviceController";
+#import "DeviceController.h"
 
 void discover_drone() {
   ARService *foundService = nil;
@@ -36,7 +34,7 @@ void discover_drone() {
 	NSString *NAME = @"RS_";
 	NSString *PREFIX = [serviceIdx.peripheral.name substringToIndex:3];
 	if ([PREFIX isEqualToString:NAME]) {
-      NSLog(@"Found a Rolling Spider!");
+	  NSLog(@"Found a Rolling Spider!");
 	  NSLog(@"%@", serviceIdx.peripheral);
 	  foundService = obj;
 	  break;
@@ -44,40 +42,42 @@ void discover_drone() {
       }
     }
   }
-
-  [ARD stop];
   
-  MiniDroneDeviceController *MDDC = [[MiniDroneDeviceController alloc] initWithService:foundService];
+  [ARD stop];
+
+  DeviceController *MDDC = [[DeviceController alloc] initWithARService:foundService];
   NSLog(@"Initialized MiniDroneDeviceController");
-  [MDDC start];
-  NSLog(@"MDDC Started");
-
+  BOOL connectError = [MDDC start];
+  if(connectError) {
+    NSLog(@"connectError = %d", connectError);
+    [MDDC stop];
+    return;
+  } else {
+    NSLog(@"MDDC Started");
+  }
+  
   // meter/sec - min: 0.5, max: 2.5
-  [MDDC userRequestedSpeedSettingsMaxVerticalSpeed:1.0];
+  [MDDC sendMaxVerticalSpeed:1.0];
   [NSThread sleepForTimeInterval:0.3];
-
+ 
   //degree - min: 5, max: 25
-  [MDDC userRequestedPilotingSettingsMaxTilt:15.0];
+  [MDDC sendMaxTilt:15.0];
   [NSThread sleepForTimeInterval:0.3];
 
   //degree/sec - min: 50, max: 360
-  [MDDC userRequestedSpeedSettingsMaxRotationSpeed:150.0];
+  [MDDC sendMaxRotationSpeed:150.0];
   [NSThread sleepForTimeInterval:0.3];
 
-  //Activate ability to tilt
-  [MDDC userCommandsActivationChanged:1];
-  [NSThread sleepForTimeInterval:0.3];
-
-  //Turn off wheels
-  [MDDC userRequestedSpeedSettingsWheels:0];
-  [NSThread sleepForTimeInterval:0.3];
-
-  //Reset state of drone (maybe unnecessary)
-  [MDDC controllerLoop];
+  //meter - min: 2, max: 10
+  [MDDC sendMaxAltitude:3];
   [NSThread sleepForTimeInterval:0.3];
   
+  //Turn off wheels
+  [MDDC sendWheelsOn:0];
+  [NSThread sleepForTimeInterval:0.3];
+
   //NSLog(@"Blink Blink");
-  //[MDDC userRequestSetAutoTakeOffMode:1];
+  //[MDDC sendAutoTakeoff:1];
   //[NSThread sleepForTimeInterval:0.3];
 
   float speed = 0.50;
@@ -96,7 +96,7 @@ void discover_drone() {
     //F - flat trim
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,3)) {
       NSLog(@"Flat trim");
-      [MDDC userRequestedFlatTrim];
+      [MDDC sendFlatTrim];
       [NSThread sleepForTimeInterval:0.25];
     }
     //+ - faster
@@ -119,17 +119,21 @@ void discover_drone() {
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,49)) {
       if(land == 1) {
 	NSLog(@"Landing");
-	[MDDC userRequestedLanding];
+	[MDDC sendLanding];
 	[NSThread sleepForTimeInterval:1];
 	land = 0;
       } else {
 	NSLog(@"Taking Off");
-	[MDDC userRequestedFlatTrim];
-	[NSThread sleepForTimeInterval:0.30];
-	[MDDC userRequestedTakeOff];
-	[NSThread sleepForTimeInterval:0.1];
-	[MDDC userRequestedFlatTrim];
-	[NSThread sleepForTimeInterval:0.30];
+	//Deactivate ability to tilt
+	[MDDC setFlag:0];
+	[MDDC sendFlatTrim];
+	[NSThread sleepForTimeInterval:0.25];
+	[MDDC sendTakeoff];
+	[NSThread sleepForTimeInterval:0.5];
+	[MDDC sendFlatTrim];
+	[NSThread sleepForTimeInterval:0.25];
+	//Reactiviate ability to tilt
+	[MDDC setFlag:1];
 	land = 1;
       }
     }
@@ -137,101 +141,87 @@ void discover_drone() {
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,36)) {
       NSLog(@"Taking Photo");
       [NSThread sleepForTimeInterval:0.25];
-      [MDDC userRequestedRecordPicture:1];
+      [MDDC sendMediaRecordPicture:1];
       [NSThread sleepForTimeInterval:1.0];
     }
     //up arrow - tilt forward
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,126)) {
       commandFound = 1;
       NSLog(@"Tilting Forwards");
-      [MDDC userPitchChanged:speed*0.5];
+      [MDDC setPitch:speed*0.5];
     }
     //back arrow - tilt backwards
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,125)) {
       commandFound = 1;
       NSLog(@"Tilting Backwards");
-      [MDDC userPitchChanged:-speed*0.5];
+      [MDDC setPitch:-speed*0.5];
     }
     //right arrow - rotate right
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,124)) {
       commandFound = 1;
       NSLog(@"Rotating Right");
-      [MDDC userYawChanged:speed];
+      [MDDC setYaw:speed];
     }
     //left arrow - rotate left
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,123)) {
       commandFound = 1;
       NSLog(@"Rotating Left");
-      [MDDC userYawChanged:-speed];
+      [MDDC setYaw:-speed];
     }
 
     //W - up
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,13)) {
       commandFound = 1;
       NSLog(@"Going Up");
-      [MDDC userGazChanged:speed*0.5];
+      [MDDC setGaz:speed*0.5];
     }
     //S - down
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,1)) {
       commandFound = 1;
       NSLog(@"Going Down");
-      [MDDC userGazChanged:-speed*0.5];
+      [MDDC setGaz:-speed*0.5];
     }
     //D - roll right
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,2)) {
       commandFound = 1;
       NSLog(@"Rolling Right");
-      [MDDC userRollChanged:speed*0.5];
+      [MDDC setRoll:speed*0.5];
     }
     //A - roll left
     if (CGEventSourceKeyState(kCGEventSourceStateCombinedSessionState,0)) {
       commandFound = 1;
       NSLog(@"Rolling Left");
-      [MDDC userRollChanged:-speed*0.5];
+      [MDDC setRoll:-speed*0.5];
     }
-    
+
+    [NSThread sleepForTimeInterval:0.15];
     if(commandFound) {
-      [MDDC controllerLoop];
       commandFound = 0;
 
-      [MDDC userGazChanged:0];
-      [MDDC userYawChanged:0];
-      [MDDC userPitchChanged:0];
-      [MDDC userRollChanged:0];
+      [MDDC setGaz:0];
+      [MDDC setYaw:0];
+      [MDDC setPitch:0];
+      [MDDC setRoll:0];
     }
-    [NSThread sleepForTimeInterval:0.15];
   }
   
-  [MDDC userRequestedLanding];
+  [MDDC sendLanding];
   [NSThread sleepForTimeInterval:2];
   
   [MDDC stop];
-  [NSThread sleepForTimeInterval:5];
   NSLog(@"MDDC Stopped");
-  
-  exit(0);
 }
 
 int main() {
   @autoreleasepool {
     dispatch_queue_t my_main_thread = dispatch_queue_create("MyMainThread", NULL);
 
-    /*
-    dispatch_async(my_main_thread,^{
-    	NSNotificationCenter *mainCenter = [NSNotificationCenter defaultCenter];
-	[mainCenter postNotificationName:@"my_notification" object:nil];
-
-	[[NSDistributedNotificationCenter defaultCenter] addObserverForName:nil object:nil queue:nil usingBlock:^(NSNotification *notification)
-							 {
-							   NSLog(@"%@", notification);
-							 }];
-      });
-    */
-
     dispatch_async(my_main_thread,^{
 	ARDiscovery *ARD = [ARDiscovery sharedInstance];
 	[ARD start];
 	discover_drone();
+	[ARD stop];
+	exit(0);
       });
     
     dispatch_async(my_main_thread, ^{


### PR DESCRIPTION
I used the code from the latest Rolling Spider iOS example and created a much simpler example for OSX. I also added functionality to the `DeviceController` such as automated discovery and, I think, all of the commands you can send to the drone. I think this is a much better sample than the previous (so we go from Cruft -> OK). It may be worthwhile to leave the cruft, in case folks are interested in working off of the original FreeFlight samples, though personally I think this new sample is far better than the previous one.

So, I submit this in case you'd like to add it. If you'd like me to change anything first, I'm happy to do so. Or, if you think the first sample is good enough, that's O.K. too.
