### PR TITLE
Fix signature deprecations

### DIFF
--- a/Contributions/OSX/RollingSpiderCruft/RSlib/DeviceController+libARCommands.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/DeviceController+libARCommands.m
@@ -404,7 +404,7 @@ static void common_camerasettingsstate_camerasettingschanged_callback(float fov,
     ARCOMMANDS_Decoder_SetCommonOverHeatStateOverHeatChangedCallback(common_overheatstate_overheatchanged_callback, (__bridge void *)(self));
     ARCOMMANDS_Decoder_SetCommonOverHeatStateOverHeatRegulationChangedCallback(common_overheatstate_overheatregulationchanged_callback, (__bridge void *)(self));
     // Command class ControllerState
-    ARCOMMANDS_Decoder_SetCommonControllerStateIsPilotingChangedCallback(common_controllerstate_ispilotingchanged_callback, (__bridge void *)(self));
+    ARCOMMANDS_Decoder_SetCommonControllerIsPilotingCallback(common_controllerstate_ispilotingchanged_callback, (__bridge void *)(self));
     // Command class WifiSettingsState
     ARCOMMANDS_Decoder_SetCommonWifiSettingsStateOutdoorSettingsChangedCallback(common_wifisettingsstate_outdoorsettingschanged_callback, (__bridge void *)(self));
     // Command class MavlinkState
@@ -444,7 +444,7 @@ static void common_camerasettingsstate_camerasettingschanged_callback(float fov,
     ARCOMMANDS_Decoder_SetCommonOverHeatStateOverHeatChangedCallback(NULL, NULL);
     ARCOMMANDS_Decoder_SetCommonOverHeatStateOverHeatRegulationChangedCallback(NULL, NULL);
     // Command class ControllerState
-    ARCOMMANDS_Decoder_SetCommonControllerStateIsPilotingChangedCallback(NULL, NULL);
+    ARCOMMANDS_Decoder_SetCommonControllerIsPilotingCallback(NULL, NULL);
     // Command class WifiSettingsState
     ARCOMMANDS_Decoder_SetCommonWifiSettingsStateOutdoorSettingsChangedCallback(NULL, NULL);
     // Command class MavlinkState

--- a/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
+++ b/Contributions/OSX/RollingSpiderCruft/RSlib/MiniDroneDeviceController.m
@@ -419,7 +419,7 @@ typedef struct
     
     // Send isPilotingChanged command
     sentStatus = NO;
-    cmdError = ARCOMMANDS_Generator_GenerateCommonControllerStateIsPilotingChanged(cmdbuf, sizeof(cmdbuf), &actualSize, (inHud ? 1 : 0));
+    cmdError = ARCOMMANDS_Generator_GenerateCommonControllerIsPiloting(cmdbuf, sizeof(cmdbuf), &actualSize, (inHud ? 1 : 0));
     if (cmdError == ARCOMMANDS_GENERATOR_OK)
     {
         sentStatus = [self sendData:cmdbuf withSize:actualSize onBufferWithId:[MiniDroneARNetworkConfig c2dAckId]withSendPolicy:ARNETWORK_SEND_POLICY_RETRY withCompletionBlock:nil];


### PR DESCRIPTION
Hi there,

As of [this change](https://github.com/Parrot-Developers/libARCommands/commit/5898658a925245555153459ea4684aa87f220e07), you can't compile the samples because the signature changed. Could you merge this fix?
